### PR TITLE
Update the endpoint to the fully qualified api path

### DIFF
--- a/harness/api/client.go
+++ b/harness/api/client.go
@@ -50,7 +50,7 @@ func NewClient() *Client {
 			HTTPClient:  httpClient,
 		}),
 		NGClient: nextgen.NewAPIClient(&nextgen.Configuration{
-			BasePath: helpers.EnvVars.NGEndpoint.GetWithDefault(DefaultNGApiUrl),
+			BasePath: helpers.EnvVars.NGEndpoint.GetWithDefault(utils.DefaultNGApiUrl),
 			DefaultHeader: map[string]string{
 				helpers.EnvVars.NGApiKey.String(): helpers.EnvVars.NGApiKey.Get(),
 			},

--- a/harness/api/consts.go
+++ b/harness/api/consts.go
@@ -1,6 +1,0 @@
-package api
-
-const (
-	GraphQLInvalidTokenErrorCode = "INVALID_TOKEN"
-	DefaultNGApiUrl              = "https://app.harness.io/gateway/ng/api"
-)

--- a/harness/cd/cac.go
+++ b/harness/cd/cac.go
@@ -56,7 +56,7 @@ func FindConfigAsCodeItemByUUID(rootItem *cac.ConfigAsCodeItem, uuid string) *ca
 }
 
 func (c *ConfigAsCodeClient) GetDirectoryItemContent(restName string, uuid string, applicationId string) (*cac.ConfigAsCodeItem, error) {
-	path := fmt.Sprintf("/gateway/api/setup-as-code/yaml/%s/%s", restName, uuid)
+	path := fmt.Sprintf("/setup-as-code/yaml/%s/%s", restName, uuid)
 	log.Printf("[DEBUG] CAC: Getting directory item content at %s", path)
 
 	req, err := c.ApiClient.NewAuthorizedGetRequest(path)
@@ -83,7 +83,7 @@ func (c *ConfigAsCodeClient) GetDirectoryItemContent(restName string, uuid strin
 }
 
 func (c *ConfigAsCodeClient) GetDirectoryTree(applicationId string) (*cac.ConfigAsCodeItem, error) {
-	path := "/gateway/api/setup-as-code/yaml/directory"
+	path := "/setup-as-code/yaml/directory"
 	log.Printf("[DEBUG] CAC: Getting directory tree for app '%s'", applicationId)
 
 	req, err := c.ApiClient.NewAuthorizedGetRequest(path)
@@ -139,7 +139,7 @@ func (c *ConfigAsCodeClient) UpsertRawYaml(filePath cac.YamlPath, yaml []byte) (
 
 	log.Printf("[TRACE] CAC: HTTP Request Body %s", string(yaml))
 
-	req, err := c.ApiClient.NewAuthorizedPostRequest("/gateway/api/setup-as-code/yaml/upsert-entity", &b)
+	req, err := c.ApiClient.NewAuthorizedPostRequest("/setup-as-code/yaml/upsert-entity", &b)
 
 	// Set proper content header
 	req.Header.Set(helpers.HTTPHeaders.ContentType.String(), w.FormDataContentType())
@@ -227,7 +227,7 @@ type ConfigAsCodeClient struct {
 
 func (c *ConfigAsCodeClient) DeleteEntity(filePath cac.YamlPath) error {
 	log.Printf("[DEBUG] CAC: Deleting entity at %s", filePath)
-	req, err := c.ApiClient.NewAuthorizedDeleteRequest("/gateway/api/setup-as-code/yaml/delete-entities")
+	req, err := c.ApiClient.NewAuthorizedDeleteRequest("/setup-as-code/yaml/delete-entities")
 
 	if err != nil {
 		return err

--- a/harness/cd/encrypted_text.go
+++ b/harness/cd/encrypted_text.go
@@ -105,7 +105,7 @@ func (c *SecretClient) GetEncryptedTextById(id string) (*graphql.EncryptedText, 
 
 // WARNING: This method requires the use of a bearer token which isn't supported in most scenarios.
 func (c *SecretClient) ListEncryptedTextSecrets(limit int, offset int) ([]*unpublished.EncryptedText, *graphql.PageInfo, error) {
-	req, err := c.ApiClient.NewAuthorizedGetRequest("/gateway/api/secrets/list-secrets-page")
+	req, err := c.ApiClient.NewAuthorizedGetRequest("/secrets/list-secrets-page")
 	if err != nil {
 		return nil, nil, err
 	}

--- a/harness/cd/graphql.go
+++ b/harness/cd/graphql.go
@@ -13,7 +13,7 @@ import (
 	"github.com/hashicorp/go-retryablehttp"
 )
 
-const DefaultGraphQLApiUrl = "/gateway/api/graphql"
+const DefaultGraphQLApiUrl = "/graphql"
 
 func (m *GraphQLResponseMessage) ToError() error {
 	return fmt.Errorf("%s %s: %s", m.Level, m.Code, m.Message)

--- a/harness/cd/graphql_test.go
+++ b/harness/cd/graphql_test.go
@@ -24,7 +24,7 @@ func TestNewGraphQLRequest(t *testing.T) {
 	// Validate
 	require.NoError(t, err)
 	require.Equal(t, fmt.Sprintf("accountId=%s", client.Configuration.AccountId), req.URL.RawQuery)
-	require.Equal(t, client.Configuration.Endpoint, fmt.Sprintf("%s://%s", req.URL.Scheme, req.Host))
+	require.Equal(t, client.Configuration.Endpoint, fmt.Sprintf("%s://%s/gateway/api", req.URL.Scheme, req.Host))
 	require.Equal(t, client.Configuration.APIKey, req.Header.Get(helpers.HTTPHeaders.ApiKey.String()))
 	require.Equal(t, helpers.HTTPHeaders.ApplicationJson.String(), req.Header.Get(helpers.HTTPHeaders.ContentType.String()))
 	require.Equal(t, helpers.HTTPHeaders.ApplicationJson.String(), req.Header.Get(helpers.HTTPHeaders.Accept.String()))

--- a/harness/cd/secret_manager.go
+++ b/harness/cd/secret_manager.go
@@ -69,7 +69,7 @@ func (ac *SecretClient) GetSecretManagerByName(name string) (*graphql.SecretMana
 
 // WARNING: This method requires the use of a bearer token which isn't supported in most scenarios.
 func (c *SecretClient) ListSecretManagers() ([]*unpublished.SecretManager, error) {
-	req, err := c.ApiClient.NewAuthorizedGetRequest("/gateway/api/secrets/list-configs")
+	req, err := c.ApiClient.NewAuthorizedGetRequest("/secrets/list-configs")
 	if err != nil {
 		return nil, err
 	}

--- a/harness/cd/ssh_credential.go
+++ b/harness/cd/ssh_credential.go
@@ -149,7 +149,7 @@ func (c *SecretClient) GetSSHCredentialByName(name string) (*graphql.SSHCredenti
 
 // WARNING: This method requires the use of a bearer token which isn't supported in most scenarios.
 func (c *SecretClient) ListSSHCredentials() ([]*unpublished.Credential, error) {
-	req, err := c.ApiClient.NewAuthorizedGetRequest("/gateway/api/secrets/list-values")
+	req, err := c.ApiClient.NewAuthorizedGetRequest("/secrets/list-values")
 	if err != nil {
 		return nil, err
 	}

--- a/harness/cd/version.go
+++ b/harness/cd/version.go
@@ -27,7 +27,7 @@ type APIVersionResponse struct {
 
 // Returns the version of Harness that we're connecting to
 func (client *ApiClient) GetAPIVersion() (*APIVersionResponse, error) {
-	req, err := client.NewAuthorizedGetRequest("/api/version")
+	req, err := client.NewAuthorizedGetRequest("/version")
 
 	if err != nil {
 		return nil, err

--- a/harness/cd/winrm_credential.go
+++ b/harness/cd/winrm_credential.go
@@ -57,7 +57,7 @@ func getWinRMCredentialFields() string {
 }
 
 func (c *SecretClient) ListWinRMCredentials() ([]*unpublished.Credential, error) {
-	req, err := c.ApiClient.NewAuthorizedGetRequest("gateway/api/secrets/list-values")
+	req, err := c.ApiClient.NewAuthorizedGetRequest("/secrets/list-values")
 	if err != nil {
 		return nil, err
 	}
@@ -103,5 +103,3 @@ func (c *SecretClient) ListWinRMCredentials() ([]*unpublished.Credential, error)
 
 	return winrmCreds, nil
 }
-
-// https://app.harness.io/gateway/api/secrets/list-values?accountId=UKh5Yts7THSMAbccG3HrLA

--- a/harness/utils/const.go
+++ b/harness/utils/const.go
@@ -1,5 +1,7 @@
 package utils
 
 const (
-	DefaultApiUrl = "https://app.harness.io"
+	DefaultApiUrl                = "https://app.harness.io/gateway/api"
+	DefaultNGApiUrl              = "https://app.harness.io/gateway/ng/api"
+	GraphQLInvalidTokenErrorCode = "INVALID_TOKEN"
 )


### PR DESCRIPTION
Fixes #64. Updates the endpoint configuration to account for the fully qualified path. So you can now set the endpoint to `https://app.harness.io/gateway/api` or `https://customer.com/api`.