### PR TITLE
chore: add webhook url data to trigger response

### DIFF
--- a/harness/nextgen/model_ng_trigger_response.go
+++ b/harness/nextgen/model_ng_trigger_response.go
@@ -22,6 +22,7 @@ type NgTriggerResponse struct {
 	Yaml              string                       `json:"yaml,omitempty"`
 	Version           int64                        `json:"version,omitempty"`
 	Enabled           bool                         `json:"enabled,omitempty"`
+	WebhookUrl        string                       `json:"webhookUrl,omitempty"`
 	Errors            map[string]map[string]string `json:"errors,omitempty"`
 	ErrorResponse     bool                         `json:"errorResponse,omitempty"`
 }


### PR DESCRIPTION
## Describe your changes

Today when creating webhook triggers we do not return from the create call the actual webhook that is created. The webhook URL is the most valuable piece of data a user needs when creating a webhook trigger. 

By adding this to the response payload we will be able to extract and use it in the Terraform provider.

<img width="1208" height="1828" alt="image" src="https://github.com/user-attachments/assets/6a201c30-777e-46c4-ad85-1129d9345930" />

## Comment Triggers

<details>
  <summary>PR Check triggers</summary>

- Build Test: `trigger build`
- Sub Category Field Check: `trigger subcategoryfieldcheck`
- Git Leaks: `trigger gitleaks`
- Message Check: `trigger messagecheck`
</details>