### PR TITLE
fix: issue with idp api and account id param

### DIFF
--- a/harness/idp/api_entities.go
+++ b/harness/idp/api_entities.go
@@ -738,6 +738,9 @@ func (a *EntitiesApiService) GetEntity(ctx context.Context, scope string, kind s
 	if localVarOptionals != nil && localVarOptionals.ResolvePlaceholders.IsSet() {
 		localVarQueryParams.Add("resolve_placeholders", parameterToString(localVarOptionals.ResolvePlaceholders.Value(), ""))
 	}
+	if localVarOptionals != nil && localVarOptionals.HarnessAccount.IsSet() {
+		localVarQueryParams.Add("accountIdentifier", parameterToString(localVarOptionals.HarnessAccount.Value(), ""))
+	}
 	// to determine the Content-Type header
 	localVarHttpContentTypes := []string{}
 


### PR DESCRIPTION
## Describe your changes

  Problem

  The harness_platform_idp_catalog_entity resource fails with 401 Unauthorized on Read operations after Create succeeds. This breaks Terraform state management for IDP entities.

  Root Cause

  Two issues:

  1. Provider: GetIDPClientWithContext() doesn't call .WithAuthContext(ctx), so the API key never gets added to the request context.
  2. SDK: The IDP API requires accountIdentifier as a query parameter for GET requests, but the SDK only sends it as a header.

  Verified with curl:
  - GET /gateway/v1/entities/account/workflow/{id} with Harness-Account header only → 401
  - GET /gateway/v1/entities/account/workflow/{id}?accountIdentifier={id} → 200

  ---
  [PR # 1: terraform-provider-harness](https://github.com/harness/terraform-provider-harness/pull/1380)

  Title: fix: Add WithAuthContext to GetIDPClientWithContext

  File: internal/session.go

  Change:
  func (s *Session) GetIDPClientWithContext(ctx context.Context) (*idp.APIClient, context.Context) {
      if ctx == nil {
          ctx = context.Background()
      }
      return s.IDPClient.WithAuthContext(ctx)  // was: return s.IDPClient, ctx
  }

  Why:
  Every other client method (GetPlatformClientWithContext, GetDBOpsClientWithContext, etc.) calls .WithAuthContext(ctx) to inject the API key. This one was missing it.

  Requires: The SDK fix below to work fully.

  ---
  PR # 2 (THIS PR): harness-go-sdk

  Title: fix(idp): Add accountIdentifier query param to GetEntity

  File: harness/idp/api_entities.go

  Change (add after line 740):
  if localVarOptionals != nil && localVarOptionals.HarnessAccount.IsSet() {
      localVarQueryParams.Add("accountIdentifier", parameterToString(localVarOptionals.HarnessAccount.Value(), ""))
  }

  Why:
  The IDP API needs accountIdentifier as a query parameter for GET requests when using API key auth. Currently only sent as Harness-Account header, which isn't enough.

  Other methods (Create/Update/Delete) work fine with just the header. This seems to be a GET-specific API requirement.

  ---
  Both fixes needed for the resource to work correctly.

## Comment Triggers

<details>
  <summary>PR Check triggers</summary>

- Build Test: `trigger build`
- Sub Category Field Check: `trigger subcategoryfieldcheck`
- Git Leaks: `trigger gitleaks`
- Message Check: `trigger messagecheck`
</details>