### PR TITLE
feat: add reportType to AwsCurAttributes for CUR 2.0

### DIFF
--- a/harness/nextgen/api/swagger.yaml
+++ b/harness/nextgen/api/swagger.yaml
@@ -30040,6 +30040,9 @@ components:
           type: string
         s3Prefix:
           type: string
+        reportType:
+          type: string
+          description: CUR format version. Use CUR2.0 for AWS Data Exports (CUR 2.0); omit for legacy CUR 1.0.
       description: This contains AWS cost and usage reports attributes
     AwsKmsConnector:
       type: object

--- a/harness/nextgen/api/swagger.yaml
+++ b/harness/nextgen/api/swagger.yaml
@@ -30042,7 +30042,10 @@ components:
           type: string
         reportType:
           type: string
-          description: CUR format version. Use CUR2.0 for AWS Data Exports (CUR 2.0); omit for legacy CUR 1.0.
+          enum:
+          - CUR1.0
+          - CUR2.0
+          description: CUR2.0 for CUR 2.0 data exports, CUR1.0 for legacy. Null defaults to CUR1.0.
       description: This contains AWS cost and usage reports attributes
     AwsKmsConnector:
       type: object

--- a/harness/nextgen/docs/AwsCurAttributes.md
+++ b/harness/nextgen/docs/AwsCurAttributes.md
@@ -7,6 +7,7 @@ Name | Type | Description | Notes
 **S3BucketName** | **string** |  | [default to null]
 **Region** | **string** |  | [optional] [default to null]
 **S3Prefix** | **string** |  | [optional] [default to null]
+**ReportType** | **string** | CUR format version. Use CUR2.0 for AWS Data Exports (CUR 2.0); omit for legacy CUR 1.0. | [optional] [default to null]
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/harness/nextgen/docs/AwsCurAttributes.md
+++ b/harness/nextgen/docs/AwsCurAttributes.md
@@ -7,7 +7,7 @@ Name | Type | Description | Notes
 **S3BucketName** | **string** |  | [default to null]
 **Region** | **string** |  | [optional] [default to null]
 **S3Prefix** | **string** |  | [optional] [default to null]
-**ReportType** | **string** | CUR format version. Use CUR2.0 for AWS Data Exports (CUR 2.0); omit for legacy CUR 1.0. | [optional] [default to null]
+**ReportType** | **string** | CUR2.0 for CUR 2.0 data exports, CUR1.0 for legacy. Null defaults to CUR1.0. | [optional] [default to null] [enum: CUR1.0, CUR2.0]
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/harness/nextgen/model_aws_cur_attributes.go
+++ b/harness/nextgen/model_aws_cur_attributes.go
@@ -15,7 +15,6 @@ type AwsCurAttributes struct {
 	S3BucketName string `json:"s3BucketName"`
 	Region       string `json:"region,omitempty"`
 	S3Prefix     string `json:"s3Prefix,omitempty"`
-	// ReportType is the CUR format version. Use "CUR2.0" for AWS Data Exports (CUR 2.0)
-	// or omit / leave empty for legacy CUR 1.0.
+	// ReportType: CUR2.0 for CUR 2.0 data exports, CUR1.0 for legacy.
 	ReportType string `json:"reportType,omitempty"`
 }

--- a/harness/nextgen/model_aws_cur_attributes.go
+++ b/harness/nextgen/model_aws_cur_attributes.go
@@ -15,4 +15,7 @@ type AwsCurAttributes struct {
 	S3BucketName string `json:"s3BucketName"`
 	Region       string `json:"region,omitempty"`
 	S3Prefix     string `json:"s3Prefix,omitempty"`
+	// ReportType is the CUR format version. Use "CUR2.0" for AWS Data Exports (CUR 2.0)
+	// or omit / leave empty for legacy CUR 1.0.
+	ReportType string `json:"reportType,omitempty"`
 }


### PR DESCRIPTION
## Describe your changes

Adds `reportType` to `AwsCurAttributes` so CEAws (CCM AWS) connectors can select CUR 2.0 via the Connectors API.

The Harness UI already supports CUR 2.0 and legacy CUR. Live connector payloads include `curAttributes.reportType` (e.g. `CUR2.0`), but the SDK model / swagger did not expose this field yet.

Changes:
- `harness/nextgen/model_aws_cur_attributes.go` — add `ReportType` (`json:"reportType,omitempty"`)
- `harness/nextgen/api/swagger.yaml` — document `reportType` on `AwsCurAttributes`
- `harness/nextgen/docs/AwsCurAttributes.md` — docs update

When unset, `omitempty` keeps the field out of the request body (legacy behavior unchanged).

This is needed to add `report_type` support on `harness_platform_connector_awscc` in the Terraform provider after an SDK release.
